### PR TITLE
dodano composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "webultd/webultdpayupaymentbundle",
+    "description": "Bundle wspierający system płatności PayU",
+    "keywords": ["webultd", "webultdpayupaymentbundle", "symfony", "bundle", "payment", "payu"],
+    "type": "symfony-bundle",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Blazej Gruszka",
+            "email": "github@gruszka.info"
+        },
+        {
+            "name": "Paweł Małolepszy",
+            "email": "p.malolepszy@itspecialist.com.pl"
+        }
+
+    ],
+    "require":{
+        "php":">=5.3.3",
+        "symfony/framework-bundle": ">=2.0,<2.2-dev"
+    },
+    "autoload": {
+        "psr-0": {
+            "webultd\\Payu\\PaymentBundle\\webultdPayuPaymentBundle":""
+        }
+    },
+    "target-dir": "webultd/Payu/PaymentBundle/webultdPayuPaymentBundle"
+}


### PR DESCRIPTION
Pomyślałem o dodaniu możliwości instalacji bundle za pomocą composera. Generalnie każdy, kto będzie chciał z niego korzystać w symfony >= 2.1, będzie musiał się trochę nagimnastykować. Z composerem wystarczy zgłosić bundle do packagist i po bólu. UWAGA! Nie testowałem, czy instalacja przebiega poprawnie. Dodałem tylko plik. 

PS.: Nie wiedziałem, czy mogę dodać siebie do sekcji authors z jednym pull requestem na koncie :). Jakby co, to można mnie wyrzucić :D. 

Pozdrawiam,
Paweł
